### PR TITLE
simqso support numpy/2.x and scipy/1.16.x

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,62 @@
+# Workflow is based on the Astropy GitHub actions workflow, ci_workflows.yml
+name: CI
+
+on:
+    push:
+        branches:
+            - '*'
+        tags:
+            - '*'
+    pull_request:
+
+# 2025-01-07
+# NERSC has Python 3.10, Numpy 1.22.4, Scipy 1.8.1, matplotlib 3.8.4, astropy 6.0.1, healpy 1.16.6, PyYAML 6.0.1
+# PyPI has Python 3.13, Numpy 2.2.1, Scipy 1.15.0, matplotlib 3.10.0, astropy 7.0.0, healpy 1.18.0, PyYAML 6.0.2
+# Numpy 1.26.4 was the last pre-2.0 Numpy.
+#
+jobs:
+    tests:
+        name: Unit tests
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                include:
+                    - os: ubuntu-latest
+                      python-version: '3.13'
+                      numpy-version: '<3'
+                      scipy-version: ''
+                      astropy-version: '<89'
+                    - os: ubuntu-latest
+                      python-version: '3.12'
+                      numpy-version: '<2.3'
+                      scipy-version: '<2'
+                      astropy-version: '<7.1'
+                    - os: ubuntu-latest
+                      python-version: '3.11'
+                      numpy-version: '<2.1'
+                      scipy-version: '<2'
+                      astropy-version: '<7'
+                    # Similar to NERSC but with last NumPy < 2.
+                    - os: ubuntu-latest
+                      python-version: '3.10'
+                      numpy-version: '<2'
+                      scipy-version: '<1.9'
+                      astropy-version: '<6.1'
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v5
+              with:
+                python-version: ${{ matrix.python-version }}
+            - name: Install Python dependencies
+              run: |
+                python -m pip install --upgrade pip setuptools wheel
+                python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
+                python -m pip install --upgrade --upgrade-strategy only-if-needed "scipy${{ matrix.scipy-version }}"
+                python -m pip install --upgrade --upgrade-strategy only-if-needed "astropy${{ matrix.astropy-version }}"
+                python -m pip install --editable .[test]
+            - name: Run the test
+              run: pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,9 +54,11 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
+                python -e pip install pytest
+                python -m pip install -r requirements.txt
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "scipy${{ matrix.scipy-version }}"
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "astropy${{ matrix.astropy-version }}"
-                python -m pip install --editable .[test]
+                python -m pip install --editable .
             - name: Run the test
               run: pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,7 +54,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -e pip install pytest
+                python -m pip install pytest
                 python -m pip install -r requirements.txt
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "scipy${{ matrix.scipy-version }}"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,16 +53,12 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                echo original pip version is
-                pip --version
                 python -m pip install --upgrade 'pip<25' setuptools wheel
-                echo updated pip version is
-                pip --version
                 python -m pip install pytest
                 python -m pip install -r requirements.txt
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "scipy${{ matrix.scipy-version }}"
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "astropy${{ matrix.astropy-version }}"
-                python -m pip install --editable .
+                python -m pip install .
             - name: Run the test
               run: pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,7 +53,11 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip setuptools wheel
+                echo original pip version is
+                pip --version
+                python -m pip install --upgrade 'pip<25' setuptools wheel
+                echo updated pip version is
+                pip --version
                 python -m pip install pytest
                 python -m pip install -r requirements.txt
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"

--- a/simqso/lumfun.py
+++ b/simqso/lumfun.py
@@ -5,8 +5,8 @@ import itertools
 from collections import OrderedDict
 import numpy as np
 from scipy.interpolate import interp1d
-from scipy.integrate import quad,dblquad,romberg,simps
-from scipy.ndimage.filters import convolve
+from scipy.integrate import quad,dblquad,romb,simpson
+from scipy.ndimage import convolve
 from scipy import optimize
 from scipy.special import hyp2f1
 from scipy.stats import poisson
@@ -220,8 +220,9 @@ class DoublePowerLawLF(LuminosityFunction):
         zin = kwargs.pop('zin',None)
         verbose = kwargs.pop('verbose',0)
         eps_M,eps_z = 5e-2,2e-2
-        nM = int(-np.diff(Mrange(zrange)) / eps_M)
-        nz = int(np.diff(zrange) / eps_z)
+        assert len(zrange) == 2
+        nM = int(-np.diff(Mrange(zrange))[0] / eps_M)
+        nz = int(np.diff(zrange)[0] / eps_z)
         if zin is None:
             # integrate across redshift to get the dN/dz distribution
             skyfrac = kwargs.get('skyArea',skyDeg2) / skyDeg2
@@ -574,9 +575,9 @@ class FastQLFIntegrator(QLFIntegrator):
     def __call__(self,Phi_Mz,p_Mz,par):
         #
         integrand = lambda M,z: Phi_Mz(M,z,par) * p_Mz(M,z) * self.dVdzdO(z)
-        inner = lambda z: romberg(integrand,*self.Mrange,args=(z,),
+        inner = lambda z: romb(integrand,*self.Mrange,args=(z,),
                                   **self.int_kwargs)
-        outer = romberg(inner,*self.zrange,**self.int_kwargs)
+        outer = romb(inner,*self.zrange,**self.int_kwargs)
         return outer
 
 class FasterQLFIntegrator(QLFIntegrator):
@@ -610,8 +611,8 @@ class FasterQLFIntegrator(QLFIntegrator):
         p_Mz_grid,mask = self._get_p_Mz_grid(p_Mz)
         Phi_Mz_grid = Phi_Mz(self.Mi,self.zi,par)
         #
-        lfsum_z = simps(Phi_Mz_grid * p_Mz_grid * self.dV, dx=self.zBinW)
-        lfsum = simps(lfsum_z, dx=self.MBinW)
+        lfsum_z = simpson(Phi_Mz_grid * p_Mz_grid * self.dV, dx=self.zBinW)
+        lfsum = simpson(lfsum_z, dx=self.MBinW)
         return lfsum
 
 def joint_qlf_likelihood_fun(par,surveys,lfintegrator,Phi_Mz,verbose):

--- a/simqso/sqbase.py
+++ b/simqso/sqbase.py
@@ -7,8 +7,8 @@ from astropy.convolution import convolve,Gaussian1DKernel
 from scipy.interpolate import interp1d,interp2d
 from astropy import units as u
 
-from pkg_resources import resource_filename
-datadir = resource_filename('simqso', 'data')
+from importlib import resources
+datadir = str(resources.files('simqso').joinpath('data'))
 
 def fixed_R_dispersion(lam1,lam2,R):
     '''Generate a wavelength grid at a fixed resolution d(log(lambda))^-1.
@@ -95,11 +95,11 @@ def continuum_kcorr(obsBand,restBand,z,alpha_nu=-0.5):
     effWave = {'SDSS-g':4670.,'SDSS-r':6165.,'SDSS-i':7471.,'SDSS-z':8918,
                'CFHT-g':4770.,'CFHT-r':6230.,'CFHT-i':7630.}
     try:
-        obsWave = float(obsBand)
+        obsWave = np.float64(obsBand)
     except:
         obsWave = effWave[obsBand]
     try:
-        restWave = float(restBand)
+        restWave = np.float64(restBand)
     except:
         restWave = effWave[restBand]
     # Following continuum K-corrections given in 

--- a/simqso/sqgrids.py
+++ b/simqso/sqgrids.py
@@ -7,7 +7,7 @@ import ast
 from copy import copy
 import numpy as np
 from scipy.interpolate import interp1d
-from scipy.integrate import simps
+from scipy.integrate import simpson
 from scipy.signal import convolve
 from scipy.stats import norm,lognorm,expon
 from astropy.io import fits
@@ -26,6 +26,10 @@ except ImportError:
         # Units
         FNU = u.erg / (u.cm**2 * u.s * u.Hz)
         FLAM = u.erg / (u.cm**2 * u.s * u.AA)
+        # if in_x is unitless, assume Angstrom
+        if not isinstance(in_x, u.Quantity):
+            in_x = in_x * u.Angstrom
+
         def blackbody_nu(in_x, temperature):
             # Convert to units for calculations, also force double precision
             with u.add_enabled_equivalencies(u.spectral() + u.temperature()):
@@ -1330,9 +1334,9 @@ def generateBEffEmissionLines(M1450,**kwargs):
         x2 = np.random.random(len(M_i))
         x3 = np.random.random(len(M_i))
     #
-    useLines = ~np.in1d(lineCatalog['name'],excludeLines)
+    useLines = ~np.isin(lineCatalog['name'],excludeLines)
     if onlyLines is not None:
-        useLines &= np.in1d(lineCatalog['name'],onlyLines)
+        useLines &= np.isin(lineCatalog['name'],onlyLines)
     if minEw is not None:
         logEw = np.polyval(lineCatalog['logEW'][:,1].T,-25)
         useLines &= logEw > np.log10(minEw)
@@ -1412,7 +1416,7 @@ class VW01FeTemplateGrid(object):
             wi1,wi2 = np.searchsorted(wave,(w1,w2))
             feTemplate[wi1:wi2] *= fscl
         # calculate the total flux (actually, EW since continuum is divided out)
-        flux0 = simps(feTemplate,wave)
+        flux0 = simpson(feTemplate,wave)
         FWHM_1Zw1 = 900.
         c_kms = 3e5
         sigma_conv = np.sqrt(FWHM_kms**2 - FWHM_1Zw1**2) / \
@@ -1422,7 +1426,7 @@ class VW01FeTemplateGrid(object):
         gkern = np.exp(-x**2/(2*sigma_conv**2)) / (np.sqrt(2*np.pi)*sigma_conv)
         broadenedTemp = convolve(feTemplate,gkern,mode='same')
         feFlux = broadenedTemp
-        feFlux *= flux0/simps(feFlux,wave)
+        feFlux *= flux0/simpson(feFlux,wave)
         return wave,feFlux
     def get(self,z):
         zi = np.searchsorted(self.zbins,z)

--- a/simqso/sqphoto.py
+++ b/simqso/sqphoto.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 from collections import OrderedDict
 from scipy.interpolate import interp1d
-from scipy.integrate import simps
+from scipy.integrate import simpson
 from scipy.constants import c
 c_Angs = c*1e10
 
@@ -332,7 +332,7 @@ def load_photo_map(photSystems):
                              fdat.Rlam.astype(np.float64),
                              bounds_error=False,fill_value=0.0,kind='slinear')
             # precompute the bandpass normalization
-            norm = simps(fdat.Rlam/fdat.lam, fdat.lam)
+            norm = simpson(fdat.Rlam/fdat.lam, fdat.lam)
             bandpasses[bpName] = dict(Rlam=fcurv,norm=norm,data=fdat)
             if photSys['uncMap'] is not None:
                 mapObserved[bpName] = photSys['uncMap'](band)

--- a/simqso/test/test_basics.py
+++ b/simqso/test/test_basics.py
@@ -1,0 +1,172 @@
+# test_simqso.py
+# Adapted from examples/SimpleSpecExample.ipynb and wrapped into a unit test
+# by LBL cborg coder
+
+import os
+import unittest
+import tempfile
+import numpy as np
+
+import astropy.units as u
+from astropy.cosmology import Planck13
+from simqso.sqgrids import *
+from simqso import sqbase
+from simqso.sqrun import buildSpectraBulk, buildQsoSpectrum
+
+# ----------------------------------------------------------------------
+# Helper function that configures and runs simqso
+# ----------------------------------------------------------------------
+def run_simqso_simulation():
+    """
+    Execute the SimQSO example code and return the wavelength grid and
+    the generated spectra.
+
+    Parameters
+    ----------
+    save_spectra : bool, optional
+        Forwarded to ``buildSpectraBulk``.  The default (False) avoids
+        writing large FITS files during testing.
+
+    Returns
+    -------
+    wave : numpy.ndarray
+        Wavelength grid (Å).
+    spectra : numpy.ndarray
+        Array of shape (n_qso, len(wave)) containing the simulated spectra.
+    """
+    # ------------------------------------------------------------------
+    # Fixed random seed for deterministic output
+    # ------------------------------------------------------------------
+    np.random.seed(12345)
+
+    # ------------------------------------------------------------------
+    # Build the wavelength grid (R = 1000, λ_min = 1000 Å, λ_max = 10 000 Å)
+    # ------------------------------------------------------------------
+    wave = sqbase.fixed_R_dispersion(1000, 10000, 1000)
+
+    # ------------------------------------------------------------------
+    # Simulation parameters
+    # ------------------------------------------------------------------
+    nqso = 5
+    M = AbsMagVar(
+        FixedSampler(np.linspace(-27, -25, nqso)[::-1]),
+        restWave=1450,
+    )
+    z = RedshiftVar(FixedSampler(np.linspace(2, 4, nqso)))
+
+    qsos = QsoSimPoints([M, z], cosmo=Planck13, units="luminosity")
+
+    # ------------------------------------------------------------------
+    # Continuum and dust components
+    # ------------------------------------------------------------------
+    contVar = BrokenPowerLawContinuumVar(
+        [GaussianSampler(-1.5, 0.3), GaussianSampler(-0.5, 0.3)],
+        [1215.0],
+    )
+
+    subDustVar = DustBlackbodyVar([ConstSampler(0.05), ConstSampler(1800.0)],
+                                 name="sublimdust")
+    subDustVar.set_associated_var(contVar)
+
+    hotDustVar = DustBlackbodyVar([ConstSampler(0.1), ConstSampler(880.0)],
+                                 name="hotdust")
+    hotDustVar.set_associated_var(contVar)
+
+    # Emission‑line component (uses the absolute‑magnitude distribution)
+    emLineVar = generateBEffEmissionLines(qsos.absMag)
+
+    # Fe‑template component
+    fescales = [
+        (0, 1540, 0.5),
+        (1540, 1680, 2.0),
+        (1680, 1868, 1.6),
+        (1868, 2140, 1.0),
+        (2140, 3500, 1.0),
+    ]
+    feVar = FeTemplateVar(VW01FeTemplateGrid(qsos.z, wave, scales=fescales))
+
+    # Register all variable components with the QSO container
+    qsos.addVars([contVar, subDustVar, hotDustVar, emLineVar, feVar])
+
+    # ------------------------------------------------------------------
+    # Build the spectra in bulk
+    # ------------------------------------------------------------------
+    _, spectra = buildSpectraBulk(wave, qsos, saveSpectra=True)
+
+    return wave, spectra
+
+
+# ----------------------------------------------------------------------
+# Test case using the standard unittest library
+# ----------------------------------------------------------------------
+class TestSimQSO(unittest.TestCase):
+    """Unittest suite for the SimQSO example."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Skip the whole suite if optional dependencies are missing."""
+        try:
+            import astropy   # noqa: F401
+            import simqso    # noqa: F401
+        except Exception as exc:   # pragma: no cover
+            raise unittest.SkipTest(
+                f"Optional dependencies not available: {exc}"
+            )
+
+    def setUp(self):
+        """Create a temporary directory to sandbox any file output."""
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        # Remember the original cwd so we can restore it later
+        self.orig_cwd = os.getcwd()
+        os.chdir(self.tmp_dir.name)
+
+    def tearDown(self):
+        """Return to the original working directory and clean up."""
+        os.chdir(self.orig_cwd)
+        self.tmp_dir.cleanup()
+
+    def test_simqso_runs_and_returns_valid_spectra(self):
+        """Smoke‑test that the SimQSO code runs and returns sensible data."""
+        wave, spectra = run_simqso_simulation()
+
+        # 1. Types
+        self.assertIsInstance(wave, np.ndarray, "wave should be a NumPy array")
+        self.assertIsInstance(spectra, np.ndarray, "spectra should be a NumPy array")
+
+        # 2. Shape – expect (n_qso, len(wave))
+        expected_n_qso = 5
+        self.assertEqual(
+            spectra.shape,
+            (expected_n_qso, len(wave)),
+            f"Expected spectra shape {(expected_n_qso, len(wave))}, got {spectra.shape}",
+        )
+
+        # 3. No NaNs / Infs – spectra should be finite numbers
+        self.assertTrue(np.isfinite(spectra).all(),
+                        "Spectra contain NaN or infinite values")
+
+        # 4. Physical sanity: fluxes should be non‑negative (tiny negative
+        #    rounding errors are allowed)
+        self.assertGreater(
+            spectra.min(),
+            -1e-12,
+            "Spectra contain unexpectedly negative values",
+        )
+
+    def test_repeatability_of_random_seed(self):
+        """Check that the fixed NumPy seed makes the output deterministic."""
+        wave1, spec1 = run_simqso_simulation()
+        wave2, spec2 = run_simqso_simulation()
+
+        # Wavelength grid is deterministic by construction
+        np.testing.assert_array_equal(wave1, wave2)
+
+        # Spectra must be identical across runs because we reset the seed each time
+        np.testing.assert_allclose(spec1, spec2, rtol=1e-12, atol=0)
+
+
+# ----------------------------------------------------------------------
+# Allow running the file directly:  python test_simqso.py
+# ----------------------------------------------------------------------
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR updates simqso to support numpy/2.x and scipy/1.16.x.  It also adds a unit test based upon the examples/SimpleSpecExample.ipynb notebook.

This PR is required for desisim support of numpy/2.x so I suggest that we review it for correctness of what it does do, but save additional updates (pyproject.toml, setup.cfg, coverage reports) for separate PRs.  I have a branch of desisim ready, but need this PR merged first for the desisim tests to pass.